### PR TITLE
#35825【機関ストレージ】 最新バージョンへの対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - '7.4'
+  - '8.1'
 
 env:
   global:
@@ -19,7 +19,7 @@ before_script:
   - git clone https://github.com/nextcloud/server.git
   - mv server/ nextcloud
   - cd nextcloud
-  - git checkout origin/stable19 -b stable19
+  - git checkout origin/stable25 -b stable25
   - mkdir custom_apps
   - cp -pi ${TRAVIS_BUILD_DIR}/travis/apps.config.php config
   - cd 3rdparty

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -4,5 +4,5 @@ declare(strict_types=1);
 
 use OCA\FileUploadNotification\AppInfo\Application;
 
-$app = \OC::$server->query(Application::class);
+$app = \OC::$server->get(Application::class);
 $app->register();

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
     <category>tools</category>
     <bugs>https://github.com/RCOSDP/nextcloud-file_upload_notification/issues</bugs>
     <dependencies>
-        <nextcloud min-version="18" max-version="19" />
+        <nextcloud min-version="25" max-version="26" />
     </dependencies>
     <settings>
         <personal>OCA\FileUploadNotification\Settings\Personal</personal>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -19,15 +19,13 @@ class Application extends App {
         /**
          * Controllers
          */
-        $container->registerService('UserHooks', function() {
-            $container = $this->getContainer();
-            $server = $container->getServer();
+        $container->registerService('UserHooks', function($c) {
             return new UserHooks(
                 self::APP_ID,
-                $server->getConfig(),
-                $server->getRootFolder(),
-                new FileUpdateMapper($server->getDatabaseConnection()),
-                $server->getLogger()
+                $c->get('ServerContainer')->getConfig(),
+                $c->get('ServerContainer')->getRootFolder(),
+                new FileUpdateMapper($c->get('ServerContainer')->getDatabaseConnection()),
+                $c->get('ServerContainer')->getLogger()
             );
         });
     }
@@ -38,6 +36,6 @@ class Application extends App {
 
     public function registerHooks() {
         $container = $this->getContainer();
-        $container->query('UserHooks')->register();
+        $container->get('UserHooks')->register();
     }
 }

--- a/lib/Controller/ConfigController.php
+++ b/lib/Controller/ConfigController.php
@@ -12,6 +12,7 @@ use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 class ConfigController extends OCSController {
 
@@ -23,7 +24,7 @@ class ConfigController extends OCSController {
                                 IRequest $request,
                                 IConfig $config,
                                 IUserSession $userSession,
-                                ILogger $logger) {
+                                LoggerInterface $logger) {
         parent::__construct($appName, $request);
         $this->config = $config;
         $this->logger = $logger;

--- a/lib/Controller/RecentController.php
+++ b/lib/Controller/RecentController.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 declare(strict_types=1);
 

--- a/lib/Controller/RecentController.php
+++ b/lib/Controller/RecentController.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 
 declare(strict_types=1);
 
@@ -222,9 +222,11 @@ class RecentController extends OCSController {
         /*
          * set since value for hook function
          */
-        $sinceKey = $userId . '#since';
-        $this->config->setAppValue($this->appName, $sinceKey, $totalRecords[0]->getUploadTime());
-        $this->logger->info('set since: ' . strval($totalRecords[0]->getUploadTime()));
+        if ($totalRecords[0] !== null) {
+            $sinceKey = $userId . '#since';
+            $this->config->setAppValue($this->appName, $sinceKey, $totalRecords[0]->getUploadTime());
+            $this->logger->info('set since: ' . strval($totalRecords[0]->getUploadTime()));
+        }
 
         return new DataResponse(
             $data,

--- a/lib/Controller/RecentController.php
+++ b/lib/Controller/RecentController.php
@@ -17,6 +17,7 @@ use OC\Files\View;
 
 use OCA\FileUploadNotification\Db\FileUpdateMapper;
 use OCA\FileUploadNotification\Db\FileCacheExtendedMapper;
+use Psr\Log\LoggerInterface;
 
 class RecentController extends OCSController {
 
@@ -34,7 +35,7 @@ class RecentController extends OCSController {
                                 IUserSession $userSession,
                                 FileUpdateMapper $updateMapper,
                                 FileCacheExtendedMapper $cacheExtendedMapper,
-                                ILogger $logger) {
+                                LoggerInterface $logger) {
         parent::__construct($appName, $request);
         $this->config = $config;
         $this->rootFolder = $rootFolder;

--- a/tests/Controller/ConfigControllerTest.php
+++ b/tests/Controller/ConfigControllerTest.php
@@ -7,7 +7,7 @@ namespace OCA\FileUploadNotification\Tests\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -37,7 +37,7 @@ class ConfigControllerTest extends \Test\TestCase {
         $this->userSession = $this->getMockBuilder(IUserSession::class)->disableOriginalConstructor()->getMock();
         $this->userSession->method('getUser')->willReturn($this->user);
 
-        $this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
     }
 
     protected function tearDown() :void {

--- a/tests/Controller/RecentControllerTest.php
+++ b/tests/Controller/RecentControllerTest.php
@@ -9,7 +9,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -54,7 +54,7 @@ class RecentControllerTest extends \Test\TestCase {
 
         $this->cacheExtendedMapper = $this->getMockBuilder(FileCacheExtendedMapper::class)->disableOriginalConstructor()->getMock();
 
-        $this->logger = $this->getMockBuilder(ILogger::class)->getMock();
+        $this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
     }
 
     protected function tearDown() :void {


### PR DESCRIPTION
## Ticket

【機関ストレージ】 最新バージョンへの対応

It corresponds to the following specifications chapter:  
4.1. Nextcloud for Institution機関ストレージ改修  
→No1: 【機関ストレージ】 最新バージョンへの対応  

## Purpose

- 【機関ストレージ】 最新バージョンへの対応 
  - Update source code to support Nextcloud version 25

## Changes

<!-- Briefly describe or list your changes  -->
- 【機関ストレージ】 最新バージョンへの対応 
  - updated config for Nextcloud version 25
  - replaced some degraded code
  - fixed error occurs when no file is uploaded for a specified time.
  - updated Travis CI config: update to PHP version 8.1 and Nextcloud version 25

## QA Notes

<!-- If applicable, briefly describe how QA should test this ticket/PR -->
<!--
  - Does this change require a data migration? If so, what data will we migrate?
  - What is the level of risk?
    - Any permission code touched?
    - Is this an additive or subtractive change, other?
  - How can QA verify? (Through UI, API, AdminApp or AdminAdminApp?)
    - If verifying through API, what's the new version? Please include the endpoints in PR notes or Dev docs.
  - What features or workflows might this change impact?
  - How will this impact performance?
-->
None

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->
None

## Side effects

<!-- Any possible side effects? -->
None

## Deployment Notes

<!-- Any special configurations for deployment? -->
None
